### PR TITLE
Fix error if max_replacements is too small

### DIFF
--- a/crem/crem.py
+++ b/crem/crem.py
@@ -303,7 +303,7 @@ def __gen_replacements(mol1, mol2, db_name, radius, dist=None, min_size=0, max_s
                         if max_replacements is not None:
                             returned_values += 1
                             if returned_values >= max_replacements:
-                                raise StopIteration
+                                return
 
         if max_replacements is not None:
             selected_row_ids = random.sample(replacements.keys(), min(len(replacements), max_replacements - returned_values))


### PR DESCRIPTION
`mutate_mol` raises `StopIteration` error when `max_replacements` is smaller than number of replacement generated. It is better to return here rather than raising error.

```python
from rdkit import Chem
from crem.crem import mutate_mol

db_name = "replacements02_sc2.5.db"
print(
    [
        m
        for m in mutate_mol(
            Chem.MolFromSmiles("CCC(C)C(N)C(N)=O"),
            db_name=db_name,
            radius=3,
            min_inc=-2,
            max_inc=2,
            max_replacements=5,
        )
    ]
)
```
```
  File "crem.py", line 418, in mutate_mol
    for frag_sma, core_sma, freq, ids in __gen_replacements(mol1=mol, mol2=None, db_name=db_name, radius=radius,
RuntimeError: generator raised StopIteration
```
